### PR TITLE
Create simple chat interface

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,119 +1,24 @@
-import { Duration } from '@/lib/duration'
-import { getModelClient } from '@/lib/models'
-import { LLMModel, LLMModelConfig } from '@/lib/models'
-import { toPrompt } from '@/lib/prompt'
-import ratelimit from '@/lib/ratelimit'
-import { fragmentSchema as schema } from '@/lib/schema'
-import { Templates } from '@/lib/templates'
-import { streamObject, LanguageModel, CoreMessage } from 'ai'
+import { getModelClient, LLMModel, LLMModelConfig } from '@/lib/models'
+import { streamText, LanguageModel, CoreMessage } from 'ai'
 
 export const maxDuration = 60
 
-const rateLimitMaxRequests = process.env.RATE_LIMIT_MAX_REQUESTS
-  ? parseInt(process.env.RATE_LIMIT_MAX_REQUESTS)
-  : 10
-const ratelimitWindow = process.env.RATE_LIMIT_WINDOW
-  ? (process.env.RATE_LIMIT_WINDOW as Duration)
-  : '1d'
-
 export async function POST(req: Request) {
-  const {
-    messages,
-    userID,
-    teamID,
-    template,
-    model,
-    config,
-  }: {
-    messages: CoreMessage[]
-    userID: string | undefined
-    teamID: string | undefined
-    template: Templates
-    model: LLMModel
-    config: LLMModelConfig
-  } = await req.json()
+  const { messages, model, config }: { messages: CoreMessage[]; model: LLMModel; config: LLMModelConfig } = await req.json()
 
-  const limit = !config.apiKey
-    ? await ratelimit(
-        req.headers.get('x-forwarded-for'),
-        rateLimitMaxRequests,
-        ratelimitWindow,
-      )
-    : false
-
-  if (limit) {
-    return new Response('You have reached your request limit for the day.', {
-      status: 429,
-      headers: {
-        'X-RateLimit-Limit': limit.amount.toString(),
-        'X-RateLimit-Remaining': limit.remaining.toString(),
-        'X-RateLimit-Reset': limit.reset.toString(),
-      },
-    })
-  }
-
-  console.log('userID', userID)
-  console.log('teamID', teamID)
-  // console.log('template', template)
-  console.log('model', model)
-  // console.log('config', config)
-
-  const { model: modelNameString, apiKey: modelApiKey, ...modelParams } = config
-  const modelClient = getModelClient(model, config)
+  const modelClient = getModelClient(model, config) as any
 
   try {
-    const stream = await streamObject({
-      model: modelClient as LanguageModel,
-      schema,
-      system: toPrompt(template),
+    const stream = await streamText({
+      model: modelClient as any,
+      system: 'You are a helpful assistant.',
       messages,
-      maxRetries: 0, // do not retry on errors
-      ...modelParams,
+      ...config,
     })
 
     return stream.toTextStreamResponse()
   } catch (error: any) {
-    const isRateLimitError =
-      error && (error.statusCode === 429 || error.message.includes('limit'))
-    const isOverloadedError =
-      error && (error.statusCode === 529 || error.statusCode === 503)
-    const isAccessDeniedError =
-      error && (error.statusCode === 403 || error.statusCode === 401)
-
-    if (isRateLimitError) {
-      return new Response(
-        'The provider is currently unavailable due to request limit. Try using your own API key.',
-        {
-          status: 429,
-        },
-      )
-    }
-
-    if (isOverloadedError) {
-      return new Response(
-        'The provider is currently unavailable. Please try again later.',
-        {
-          status: 529,
-        },
-      )
-    }
-
-    if (isAccessDeniedError) {
-      return new Response(
-        'Access denied. Please make sure your API key is valid.',
-        {
-          status: 403,
-        },
-      )
-    }
-
     console.error('Error:', error)
-
-    return new Response(
-      'An unexpected error has occurred. Please try again later.',
-      {
-        status: 500,
-      },
-    )
+    return new Response('An unexpected error has occurred. Please try again later.', { status: 500 })
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,30 +3,18 @@ import { PostHogProvider, ThemeProvider } from './providers'
 import { Toaster } from '@/components/ui/toaster'
 import { Analytics } from '@vercel/analytics/next'
 import type { Metadata } from 'next'
-import { Inter } from 'next/font/google'
-
-const inter = Inter({ subsets: ['latin'] })
 
 export const metadata: Metadata = {
-  title: 'Fragments by E2B',
-  description: "Open-source version of Anthropic's Artifacts",
+  title: 'Chat App',
+  description: 'Simple chat bot',
 }
 
-export default function RootLayout({
-  children,
-}: Readonly<{
-  children: React.ReactNode
-}>) {
+export default function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
   return (
     <html lang="en" suppressHydrationWarning>
       <PostHogProvider>
-        <body className={inter.className}>
-          <ThemeProvider
-            attribute="class"
-            defaultTheme="dark"
-            enableSystem
-            disableTransitionOnChange
-          >
+        <body className="font-sans">
+          <ThemeProvider attribute="class" defaultTheme="dark" enableSystem disableTransitionOnChange>
             {children}
           </ThemeProvider>
           <Toaster />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,337 +1,47 @@
 'use client'
 
-import { ViewType } from '@/components/auth'
-import { AuthDialog } from '@/components/auth-dialog'
 import { Chat } from '@/components/chat'
 import { ChatInput } from '@/components/chat-input'
 import { ChatPicker } from '@/components/chat-picker'
-import { ChatSettings } from '@/components/chat-settings'
-import { NavBar } from '@/components/navbar'
-import { Preview } from '@/components/preview'
-import { useAuth } from '@/lib/auth'
-import { Message, toAISDKMessages, toMessageImage } from '@/lib/messages'
 import { LLMModelConfig } from '@/lib/models'
 import modelsList from '@/lib/models.json'
-import { FragmentSchema, fragmentSchema as schema } from '@/lib/schema'
-import { supabase } from '@/lib/supabase'
-import templates, { TemplateId } from '@/lib/templates'
-import { ExecutionResult } from '@/lib/types'
-import { DeepPartial } from 'ai'
-import { experimental_useObject as useObject } from 'ai/react'
-import { usePostHog } from 'posthog-js/react'
-import { SetStateAction, useEffect, useState } from 'react'
+import { useChat } from 'ai/react'
 import { useLocalStorage } from 'usehooks-ts'
 
 export default function Home() {
-  const [chatInput, setChatInput] = useLocalStorage('chat', '')
-  const [files, setFiles] = useState<File[]>([])
-  const [selectedTemplate, setSelectedTemplate] = useState<'auto' | TemplateId>(
-    'auto',
-  )
-  const [languageModel, setLanguageModel] = useLocalStorage<LLMModelConfig>(
-    'languageModel',
-    {
-      model: 'claude-3-5-sonnet-latest',
-    },
-  )
-
-  const posthog = usePostHog()
-
-  const [result, setResult] = useState<ExecutionResult>()
-  const [messages, setMessages] = useState<Message[]>([])
-  const [fragment, setFragment] = useState<DeepPartial<FragmentSchema>>()
-  const [currentTab, setCurrentTab] = useState<'code' | 'fragment'>('code')
-  const [isPreviewLoading, setIsPreviewLoading] = useState(false)
-  const [isAuthDialogOpen, setAuthDialog] = useState(false)
-  const [authView, setAuthView] = useState<ViewType>('sign_in')
-  const [isRateLimited, setIsRateLimited] = useState(false)
-  const [errorMessage, setErrorMessage] = useState('')
-  const { session, userTeam } = useAuth(setAuthDialog, setAuthView)
-
-  const filteredModels = modelsList.models.filter((model) => {
-    if (process.env.NEXT_PUBLIC_HIDE_LOCAL_MODELS) {
-      return model.providerId !== 'ollama'
-    }
-    return true
+  const [languageModel, setLanguageModel] = useLocalStorage<LLMModelConfig>('languageModel', {
+    model: modelsList.models[0].id,
   })
 
-  const currentModel = filteredModels.find(
-    (model) => model.id === languageModel.model,
-  )
-  const currentTemplate =
-    selectedTemplate === 'auto'
-      ? templates
-      : { [selectedTemplate]: templates[selectedTemplate] }
-  const lastMessage = messages[messages.length - 1]
+  const currentModel = modelsList.models.find((m) => m.id === languageModel.model)!
 
-  const { object, submit, isLoading, stop, error } = useObject({
+  const {
+    messages,
+    input,
+    handleInputChange,
+    handleSubmit,
+    isLoading,
+  } = useChat({
     api: '/api/chat',
-    schema,
-    onError: (error) => {
-      console.error('Error submitting request:', error)
-      if (error.message.includes('limit')) {
-        setIsRateLimited(true)
-      }
-
-      setErrorMessage(error.message)
-    },
-    onFinish: async ({ object: fragment, error }) => {
-      if (!error) {
-        // send it to /api/sandbox
-        console.log('fragment', fragment)
-        setIsPreviewLoading(true)
-        posthog.capture('fragment_generated', {
-          template: fragment?.template,
-        })
-
-        const response = await fetch('/api/sandbox', {
-          method: 'POST',
-          body: JSON.stringify({
-            fragment,
-            userID: session?.user?.id,
-            teamID: userTeam?.id,
-            accessToken: session?.access_token,
-          }),
-        })
-
-        const result = await response.json()
-        console.log('result', result)
-        posthog.capture('sandbox_created', { url: result.url })
-
-        setResult(result)
-        setCurrentPreview({ fragment, result })
-        setMessage({ result })
-        setCurrentTab('fragment')
-        setIsPreviewLoading(false)
-      }
-    },
+    body: { model: currentModel, config: languageModel },
   })
-
-  useEffect(() => {
-    if (object) {
-      setFragment(object)
-      const content: Message['content'] = [
-        { type: 'text', text: object.commentary || '' },
-        { type: 'code', text: object.code || '' },
-      ]
-
-      if (!lastMessage || lastMessage.role !== 'assistant') {
-        addMessage({
-          role: 'assistant',
-          content,
-          object,
-        })
-      }
-
-      if (lastMessage && lastMessage.role === 'assistant') {
-        setMessage({
-          content,
-          object,
-        })
-      }
-    }
-  }, [object])
-
-  useEffect(() => {
-    if (error) stop()
-  }, [error])
-
-  function setMessage(message: Partial<Message>, index?: number) {
-    setMessages((previousMessages) => {
-      const updatedMessages = [...previousMessages]
-      updatedMessages[index ?? previousMessages.length - 1] = {
-        ...previousMessages[index ?? previousMessages.length - 1],
-        ...message,
-      }
-
-      return updatedMessages
-    })
-  }
-
-  async function handleSubmitAuth(e: React.FormEvent<HTMLFormElement>) {
-    e.preventDefault()
-
-    if (!session) {
-      return setAuthDialog(true)
-    }
-
-    if (isLoading) {
-      stop()
-    }
-
-    const content: Message['content'] = [{ type: 'text', text: chatInput }]
-    const images = await toMessageImage(files)
-
-    if (images.length > 0) {
-      images.forEach((image) => {
-        content.push({ type: 'image', image })
-      })
-    }
-
-    const updatedMessages = addMessage({
-      role: 'user',
-      content,
-    })
-
-    submit({
-      userID: session?.user?.id,
-      teamID: userTeam?.id,
-      messages: toAISDKMessages(updatedMessages),
-      template: currentTemplate,
-      model: currentModel,
-      config: languageModel,
-    })
-
-    setChatInput('')
-    setFiles([])
-    setCurrentTab('code')
-
-    posthog.capture('chat_submit', {
-      template: selectedTemplate,
-      model: languageModel.model,
-    })
-  }
-
-  function retry() {
-    submit({
-      userID: session?.user?.id,
-      teamID: userTeam?.id,
-      messages: toAISDKMessages(messages),
-      template: currentTemplate,
-      model: currentModel,
-      config: languageModel,
-    })
-  }
-
-  function addMessage(message: Message) {
-    setMessages((previousMessages) => [...previousMessages, message])
-    return [...messages, message]
-  }
-
-  function handleSaveInputChange(e: React.ChangeEvent<HTMLTextAreaElement>) {
-    setChatInput(e.target.value)
-  }
-
-  function handleFileChange(change: SetStateAction<File[]>) {
-    setFiles(change)
-  }
-
-  function logout() {
-    supabase
-      ? supabase.auth.signOut()
-      : console.warn('Supabase is not initialized')
-  }
-
-  function handleLanguageModelChange(e: LLMModelConfig) {
-    setLanguageModel({ ...languageModel, ...e })
-  }
-
-  function handleSocialClick(target: 'github' | 'x' | 'discord') {
-    if (target === 'github') {
-      window.open('https://github.com/e2b-dev/fragments', '_blank')
-    } else if (target === 'x') {
-      window.open('https://x.com/e2b_dev', '_blank')
-    } else if (target === 'discord') {
-      window.open('https://discord.gg/U7KEcGErtQ', '_blank')
-    }
-
-    posthog.capture(`${target}_click`)
-  }
-
-  function handleClearChat() {
-    stop()
-    setChatInput('')
-    setFiles([])
-    setMessages([])
-    setFragment(undefined)
-    setResult(undefined)
-    setCurrentTab('code')
-    setIsPreviewLoading(false)
-  }
-
-  function setCurrentPreview(preview: {
-    fragment: DeepPartial<FragmentSchema> | undefined
-    result: ExecutionResult | undefined
-  }) {
-    setFragment(preview.fragment)
-    setResult(preview.result)
-  }
-
-  function handleUndo() {
-    setMessages((previousMessages) => [...previousMessages.slice(0, -2)])
-    setCurrentPreview({ fragment: undefined, result: undefined })
-  }
 
   return (
     <main className="flex min-h-screen max-h-screen">
-      {supabase && (
-        <AuthDialog
-          open={isAuthDialogOpen}
-          setOpen={setAuthDialog}
-          view={authView}
-          supabase={supabase}
-        />
-      )}
-      <div className="grid w-full md:grid-cols-2">
-        <div
-          className={`flex flex-col w-full max-h-full max-w-[800px] mx-auto px-4 overflow-auto ${fragment ? 'col-span-1' : 'col-span-2'}`}
+      <div className="flex flex-col w-full max-h-full max-w-[800px] mx-auto px-4">
+        <Chat messages={messages as any} isLoading={isLoading} />
+        <ChatInput
+          input={input}
+          handleInputChange={handleInputChange}
+          handleSubmit={handleSubmit}
+          isLoading={isLoading}
         >
-          <NavBar
-            session={session}
-            showLogin={() => setAuthDialog(true)}
-            signOut={logout}
-            onSocialClick={handleSocialClick}
-            onClear={handleClearChat}
-            canClear={messages.length > 0}
-            canUndo={messages.length > 1 && !isLoading}
-            onUndo={handleUndo}
+          <ChatPicker
+            models={modelsList.models}
+            languageModel={languageModel}
+            onLanguageModelChange={setLanguageModel}
           />
-          <Chat
-            messages={messages}
-            isLoading={isLoading}
-            setCurrentPreview={setCurrentPreview}
-          />
-          <ChatInput
-            retry={retry}
-            isErrored={error !== undefined}
-            errorMessage={errorMessage}
-            isLoading={isLoading}
-            isRateLimited={isRateLimited}
-            stop={stop}
-            input={chatInput}
-            handleInputChange={handleSaveInputChange}
-            handleSubmit={handleSubmitAuth}
-            isMultiModal={currentModel?.multiModal || false}
-            files={files}
-            handleFileChange={handleFileChange}
-          >
-            <ChatPicker
-              templates={templates}
-              selectedTemplate={selectedTemplate}
-              onSelectedTemplateChange={setSelectedTemplate}
-              models={filteredModels}
-              languageModel={languageModel}
-              onLanguageModelChange={handleLanguageModelChange}
-            />
-            <ChatSettings
-              languageModel={languageModel}
-              onLanguageModelChange={handleLanguageModelChange}
-              apiKeyConfigurable={!process.env.NEXT_PUBLIC_NO_API_KEY_INPUT}
-              baseURLConfigurable={!process.env.NEXT_PUBLIC_NO_BASE_URL_INPUT}
-            />
-          </ChatInput>
-        </div>
-        <Preview
-          teamID={userTeam?.id}
-          accessToken={session?.access_token}
-          selectedTab={currentTab}
-          onSelectedTabChange={setCurrentTab}
-          isChatLoading={isLoading}
-          isPreviewLoading={isPreviewLoading}
-          fragment={fragment}
-          result={result as ExecutionResult}
-          onClose={() => setFragment(undefined)}
-        />
+        </ChatInput>
       </div>
     </main>
   )

--- a/components/chat-input.tsx
+++ b/components/chat-input.tsx
@@ -1,280 +1,34 @@
 'use client'
 
-import { RepoBanner } from './repo-banner'
 import { Button } from '@/components/ui/button'
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@/components/ui/tooltip'
-import { isFileInArray } from '@/lib/utils'
-import { ArrowUp, Paperclip, Square, X } from 'lucide-react'
-import { SetStateAction, useEffect, useMemo, useState } from 'react'
-import TextareaAutosize from 'react-textarea-autosize'
+import { Input } from '@/components/ui/input'
+import { FormEvent } from 'react'
 
 export function ChatInput({
-  retry,
-  isErrored,
-  errorMessage,
-  isLoading,
-  isRateLimited,
-  stop,
   input,
   handleInputChange,
   handleSubmit,
-  isMultiModal,
-  files,
-  handleFileChange,
+  isLoading,
   children,
 }: {
-  retry: () => void
-  isErrored: boolean
-  errorMessage: string
-  isLoading: boolean
-  isRateLimited: boolean
-  stop: () => void
   input: string
-  handleInputChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void
-  handleSubmit: (e: React.FormEvent<HTMLFormElement>) => void
-  isMultiModal: boolean
-  files: File[]
-  handleFileChange: (change: SetStateAction<File[]>) => void
+  handleInputChange: (e: React.ChangeEvent<HTMLInputElement>) => void
+  handleSubmit: (e: FormEvent<HTMLFormElement>) => void
+  isLoading: boolean
   children: React.ReactNode
 }) {
-  function handleFileInput(e: React.ChangeEvent<HTMLInputElement>) {
-    handleFileChange((prev) => {
-      const newFiles = Array.from(e.target.files || [])
-      const uniqueFiles = newFiles.filter((file) => !isFileInArray(file, prev))
-      return [...prev, ...uniqueFiles]
-    })
-  }
-
-  function handleFileRemove(file: File) {
-    handleFileChange((prev) => prev.filter((f) => f !== file))
-  }
-
-  function handlePaste(e: React.ClipboardEvent<HTMLTextAreaElement>) {
-    const items = Array.from(e.clipboardData.items)
-
-    for (const item of items) {
-      if (item.type.indexOf('image') !== -1) {
-        e.preventDefault()
-
-        const file = item.getAsFile()
-        if (file) {
-          handleFileChange((prev) => {
-            if (!isFileInArray(file, prev)) {
-              return [...prev, file]
-            }
-            return prev
-          })
-        }
-      }
-    }
-  }
-
-  const [dragActive, setDragActive] = useState(false)
-
-  function handleDrag(e: React.DragEvent) {
-    e.preventDefault()
-    e.stopPropagation()
-    if (e.type === 'dragenter' || e.type === 'dragover') {
-      setDragActive(true)
-    } else if (e.type === 'dragleave') {
-      setDragActive(false)
-    }
-  }
-
-  function handleDrop(e: React.DragEvent) {
-    e.preventDefault()
-    e.stopPropagation()
-    setDragActive(false)
-
-    const droppedFiles = Array.from(e.dataTransfer.files).filter((file) =>
-      file.type.startsWith('image/'),
-    )
-
-    if (droppedFiles.length > 0) {
-      handleFileChange((prev) => {
-        const uniqueFiles = droppedFiles.filter(
-          (file) => !isFileInArray(file, prev),
-        )
-        return [...prev, ...uniqueFiles]
-      })
-    }
-  }
-
-  const filePreview = useMemo(() => {
-    if (files.length === 0) return null
-    return Array.from(files).map((file) => {
-      return (
-        <div className="relative" key={file.name}>
-          <span
-            onClick={() => handleFileRemove(file)}
-            className="absolute top-[-8] right-[-8] bg-muted rounded-full p-1"
-          >
-            <X className="h-3 w-3 cursor-pointer" />
-          </span>
-          <img
-            src={URL.createObjectURL(file)}
-            alt={file.name}
-            className="rounded-xl w-10 h-10 object-cover"
-          />
-        </div>
-      )
-    })
-  }, [files])
-
-  function onEnter(e: React.KeyboardEvent<HTMLFormElement>) {
-    if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
-      e.preventDefault()
-      if (e.currentTarget.checkValidity()) {
-        handleSubmit(e)
-      } else {
-        e.currentTarget.reportValidity()
-      }
-    }
-  }
-
-  useEffect(() => {
-    if (!isMultiModal) {
-      handleFileChange([])
-    }
-  }, [isMultiModal])
-
   return (
-    <form
-      onSubmit={handleSubmit}
-      onKeyDown={onEnter}
-      className="mb-2 mt-auto flex flex-col bg-background"
-      onDragEnter={isMultiModal ? handleDrag : undefined}
-      onDragLeave={isMultiModal ? handleDrag : undefined}
-      onDragOver={isMultiModal ? handleDrag : undefined}
-      onDrop={isMultiModal ? handleDrop : undefined}
-    >
-      {isErrored && (
-        <div
-          className={`flex items-center p-1.5 text-sm font-medium mx-4 mb-10 rounded-xl ${
-            isRateLimited
-              ? 'bg-orange-400/10 text-orange-400'
-              : 'bg-red-400/10 text-red-400'
-          }`}
-        >
-          <span className="flex-1 px-1.5">{errorMessage}</span>
-          <button
-            className={`px-2 py-1 rounded-sm ${
-              isRateLimited ? 'bg-orange-400/20' : 'bg-red-400/20'
-            }`}
-            onClick={retry}
-          >
-            Try again
-          </button>
-        </div>
-      )}
-      <div className="relative">
-        <RepoBanner className="absolute bottom-full inset-x-2 translate-y-1 z-0 pb-2" />
-        <div
-          className={`shadow-md rounded-2xl relative z-10 bg-background border ${
-            dragActive
-              ? 'before:absolute before:inset-0 before:rounded-2xl before:border-2 before:border-dashed before:border-primary'
-              : ''
-          }`}
-        >
-          <div className="flex items-center px-3 py-2 gap-1">{children}</div>
-          <TextareaAutosize
-            autoFocus={true}
-            minRows={1}
-            maxRows={5}
-            className="text-normal px-3 resize-none ring-0 bg-inherit w-full m-0 outline-none"
-            required={true}
-            placeholder="Describe your app..."
-            disabled={isErrored}
-            value={input}
-            onChange={handleInputChange}
-            onPaste={isMultiModal ? handlePaste : undefined}
-          />
-          <div className="flex p-3 gap-2 items-center">
-            <input
-              type="file"
-              id="multimodal"
-              name="multimodal"
-              accept="image/*"
-              multiple={true}
-              className="hidden"
-              onChange={handleFileInput}
-            />
-            <div className="flex items-center flex-1 gap-2">
-              <TooltipProvider>
-                <Tooltip delayDuration={0}>
-                  <TooltipTrigger asChild>
-                    <Button
-                      disabled={!isMultiModal || isErrored}
-                      type="button"
-                      variant="outline"
-                      size="icon"
-                      className="rounded-xl h-10 w-10"
-                      onClick={(e) => {
-                        e.preventDefault()
-                        document.getElementById('multimodal')?.click()
-                      }}
-                    >
-                      <Paperclip className="h-5 w-5" />
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent>Add attachments</TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-              {files.length > 0 && filePreview}
-            </div>
-            <div>
-              {!isLoading ? (
-                <TooltipProvider>
-                  <Tooltip delayDuration={0}>
-                    <TooltipTrigger asChild>
-                      <Button
-                        disabled={isErrored}
-                        variant="default"
-                        size="icon"
-                        type="submit"
-                        className="rounded-xl h-10 w-10"
-                      >
-                        <ArrowUp className="h-5 w-5" />
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent>Send message</TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
-              ) : (
-                <TooltipProvider>
-                  <Tooltip delayDuration={0}>
-                    <TooltipTrigger asChild>
-                      <Button
-                        variant="secondary"
-                        size="icon"
-                        className="rounded-xl h-10 w-10"
-                        onClick={(e) => {
-                          e.preventDefault()
-                          stop()
-                        }}
-                      >
-                        <Square className="h-5 w-5" />
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent>Stop generation</TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
-              )}
-            </div>
-          </div>
-        </div>
+    <form onSubmit={handleSubmit} className="mt-auto flex flex-col gap-2">
+      <div className="flex items-center gap-2">
+        {children}
+        <Input
+          value={input}
+          onChange={handleInputChange}
+          placeholder="Type a message..."
+          className="flex-1"
+        />
+        <Button type="submit" disabled={isLoading}>Send</Button>
       </div>
-      <p className="text-xs text-muted-foreground mt-2 text-center">
-        Fragments is an open-source project made by{' '}
-        <a href="https://e2b.dev" target="_blank" className="text-[#ff8800]">
-          ✶ E2B
-        </a>
-      </p>
     </form>
   )
 }

--- a/components/chat-picker.tsx
+++ b/components/chat-picker.tsx
@@ -8,102 +8,48 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { LLMModel, LLMModelConfig } from '@/lib/models'
-import { TemplateId, Templates } from '@/lib/templates'
 import 'core-js/features/object/group-by.js'
-import { Sparkles } from 'lucide-react'
 import Image from 'next/image'
 
 export function ChatPicker({
-  templates,
-  selectedTemplate,
-  onSelectedTemplateChange,
   models,
   languageModel,
   onLanguageModelChange,
 }: {
-  templates: Templates
-  selectedTemplate: 'auto' | TemplateId
-  onSelectedTemplateChange: (template: 'auto' | TemplateId) => void
   models: LLMModel[]
   languageModel: LLMModelConfig
   onLanguageModelChange: (config: LLMModelConfig) => void
 }) {
   return (
-    <div className="flex items-center space-x-2">
-      <div className="flex flex-col">
-        <Select
-          name="template"
-          defaultValue={selectedTemplate}
-          onValueChange={onSelectedTemplateChange}
-        >
-          <SelectTrigger className="whitespace-nowrap border-none shadow-none focus:ring-0 px-0 py-0 h-6 text-xs">
-            <SelectValue placeholder="Select a persona" />
-          </SelectTrigger>
-          <SelectContent side="top">
-            <SelectGroup>
-              <SelectLabel>Persona</SelectLabel>
-              <SelectItem value="auto">
+    <Select
+      name="languageModel"
+      defaultValue={languageModel.model}
+      onValueChange={(e) => onLanguageModelChange({ ...languageModel, model: e })}
+    >
+      <SelectTrigger className="whitespace-nowrap border-none shadow-none focus:ring-0 px-0 py-0 h-6 text-xs">
+        <SelectValue placeholder="Language model" />
+      </SelectTrigger>
+      <SelectContent>
+        {Object.entries(Object.groupBy(models, ({ provider }) => provider)).map(([provider, models]) => (
+          <SelectGroup key={provider}>
+            <SelectLabel>{provider}</SelectLabel>
+            {models?.map((model) => (
+              <SelectItem key={model.id} value={model.id}>
                 <div className="flex items-center space-x-2">
-                  <Sparkles
-                    className="flex text-[#a1a1aa]"
+                  <Image
+                    className="flex"
+                    src={`/thirdparty/logos/${model.providerId}.svg`}
+                    alt={model.provider}
                     width={14}
                     height={14}
                   />
-                  <span>Auto</span>
+                  <span>{model.name}</span>
                 </div>
               </SelectItem>
-              {Object.entries(templates).map(([templateId, template]) => (
-                <SelectItem key={templateId} value={templateId}>
-                  <div className="flex items-center space-x-2">
-                    <Image
-                      className="flex"
-                      src={`/thirdparty/templates/${templateId}.svg`}
-                      alt={templateId}
-                      width={14}
-                      height={14}
-                    />
-                    <span>{template.name}</span>
-                  </div>
-                </SelectItem>
-              ))}
-            </SelectGroup>
-          </SelectContent>
-        </Select>
-      </div>
-      <div className="flex flex-col">
-        <Select
-          name="languageModel"
-          defaultValue={languageModel.model}
-          onValueChange={(e) => onLanguageModelChange({ model: e })}
-        >
-          <SelectTrigger className="whitespace-nowrap border-none shadow-none focus:ring-0 px-0 py-0 h-6 text-xs">
-            <SelectValue placeholder="Language model" />
-          </SelectTrigger>
-          <SelectContent>
-            {Object.entries(
-              Object.groupBy(models, ({ provider }) => provider),
-            ).map(([provider, models]) => (
-              <SelectGroup key={provider}>
-                <SelectLabel>{provider}</SelectLabel>
-                {models?.map((model) => (
-                  <SelectItem key={model.id} value={model.id}>
-                    <div className="flex items-center space-x-2">
-                      <Image
-                        className="flex"
-                        src={`/thirdparty/logos/${model.providerId}.svg`}
-                        alt={model.provider}
-                        width={14}
-                        height={14}
-                      />
-                      <span>{model.name}</span>
-                    </div>
-                  </SelectItem>
-                ))}
-              </SelectGroup>
             ))}
-          </SelectContent>
-        </Select>
-      </div>
-    </div>
+          </SelectGroup>
+        ))}
+      </SelectContent>
+    </Select>
   )
 }

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -1,22 +1,10 @@
+'use client'
+
 import { Message } from '@/lib/messages'
-import { FragmentSchema } from '@/lib/schema'
-import { ExecutionResult } from '@/lib/types'
-import { DeepPartial } from 'ai'
-import { LoaderIcon, Terminal } from 'lucide-react'
+import { LoaderIcon } from 'lucide-react'
 import { useEffect } from 'react'
 
-export function Chat({
-  messages,
-  isLoading,
-  setCurrentPreview,
-}: {
-  messages: Message[]
-  isLoading: boolean
-  setCurrentPreview: (preview: {
-    fragment: DeepPartial<FragmentSchema> | undefined
-    result: ExecutionResult | undefined
-  }) => void
-}) {
+export function Chat({ messages, isLoading }: { messages: Message[]; isLoading: boolean }) {
   useEffect(() => {
     const chatContainer = document.getElementById('chat-container')
     if (chatContainer) {
@@ -25,13 +13,14 @@ export function Chat({
   }, [JSON.stringify(messages)])
 
   return (
-    <div
-      id="chat-container"
-      className="flex flex-col pb-12 gap-2 overflow-y-auto max-h-full"
-    >
+    <div id="chat-container" className="flex flex-col pb-12 gap-2 overflow-y-auto max-h-full">
       {messages.map((message: Message, index: number) => (
         <div
-          className={`flex flex-col px-4 shadow-sm whitespace-pre-wrap ${message.role !== 'user' ? 'bg-accent dark:bg-white/5 border text-accent-foreground dark:text-muted-foreground py-4 rounded-2xl gap-4 w-full' : 'bg-gradient-to-b from-black/5 to-black/10 dark:from-black/30 dark:to-black/50 py-2 rounded-xl gap-2 w-fit'} font-serif`}
+          className={`flex flex-col px-4 shadow-sm whitespace-pre-wrap ${
+            message.role !== 'user'
+              ? 'bg-accent dark:bg-white/5 border text-accent-foreground dark:text-muted-foreground py-4 rounded-2xl gap-4 w-full'
+              : 'bg-gradient-to-b from-black/5 to-black/10 dark:from-black/30 dark:to-black/50 py-2 rounded-xl gap-2 w-fit'
+          } font-serif`}
           key={index}
         >
           {message.content.map((content, id) => {
@@ -43,35 +32,12 @@ export function Chat({
                 <img
                   key={id}
                   src={content.image}
-                  alt="fragment"
+                  alt="image"
                   className="mr-2 inline-block w-12 h-12 object-cover rounded-lg bg-white mb-2"
                 />
               )
             }
           })}
-          {message.object && (
-            <div
-              onClick={() =>
-                setCurrentPreview({
-                  fragment: message.object,
-                  result: message.result,
-                })
-              }
-              className="py-2 pl-2 w-full md:w-max flex items-center border rounded-xl select-none hover:bg-white dark:hover:bg-white/5 hover:cursor-pointer"
-            >
-              <div className="rounded-[0.5rem] w-10 h-10 bg-black/5 dark:bg-white/5 self-stretch flex items-center justify-center">
-                <Terminal strokeWidth={2} className="text-[#FF8800]" />
-              </div>
-              <div className="pl-2 pr-4 flex flex-col">
-                <span className="font-bold font-sans text-sm text-primary">
-                  {message.object.title}
-                </span>
-                <span className="font-sans text-sm text-muted-foreground">
-                  Click to see fragment
-                </span>
-              </div>
-            </div>
-          )}
         </div>
       ))}
       {isLoading && (

--- a/lib/prompt.ts
+++ b/lib/prompt.ts
@@ -1,15 +1,3 @@
-import { Templates, templatesToPrompt } from '@/lib/templates'
-
-export function toPrompt(template: Templates) {
-  return `
-    You are a skilled software engineer.
-    You do not make mistakes.
-    Generate an fragment.
-    You can install additional dependencies.
-    Do not touch project dependencies files like package.json, package-lock.json, requirements.txt, etc.
-    Do not wrap code in backticks.
-    Always break the lines correctly.
-    You can use one of the following templates:
-    ${templatesToPrompt(template)}
-  `
+export function toPrompt() {
+  return 'You are a helpful assistant.'
 }


### PR DESCRIPTION
## Summary
- replace complex E2B app with a minimal chat bot
- simplify API route to stream chat responses with a generic system prompt
- clean up chat components and layout

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684aa6e92ef8832983c5dbb7abb068e7

## Summary by Sourcery

Provide a minimal chat bot interface by stripping out complex E2B-specific features and refactoring the frontend and API to use ai/react's useChat with a generic system prompt.

New Features:
- Integrate ai/react's useChat hook to manage chat state and streaming

Enhancements:
- Remove authentication, templates, file attachments, previews, and analytics to streamline the interface
- Simplify Chat, ChatInput, ChatPicker components to minimal UI for basic messaging
- Refactor API route to stream plain text with a generic system prompt and drop rate limiting and schema enforcement
- Consolidate language model selection by grouping models by provider

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Streamlined chat interface for a simpler and more focused user experience.

- **Refactor**
  - Simplified chat input to support only text messages.
  - Reduced chat picker to a single language model selector.
  - Flattened and decluttered the main chat page layout.
  - Removed all persona/template selection and preview features.
  - Updated app metadata and font styling for a cleaner appearance.

- **Bug Fixes**
  - Removed rate limiting and error handling messages for a more consistent chat flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->